### PR TITLE
feat: improves max recursion limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import sys
 import json
 from os.path import isfile
 
@@ -14,6 +15,8 @@ if __name__ == "__main__":
 
     with open(input_file) as file:
         data = json.load(file, object_hook=to_ast_node)
+
+        sys.setrecursionlimit(100000)
 
         file = File(**data)
         file.expression.execute()

--- a/tests/nodes/test_first.py
+++ b/tests/nodes/test_first.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nodes import First, Int, Tuple, Var
+from nodes import First, Int, Tuple, Var, HashableDict
 
 
 class TestFirst:
@@ -24,6 +24,6 @@ class TestFirst:
                 Var("foo"),
                 Var("bar"),
             )
-        ).execute(namespace={"foo": "foo value", "bar": "bar value"})
+        ).execute(namespace=HashableDict({"foo": "foo value", "bar": "bar value"}))
 
         assert result == "foo value"

--- a/tests/nodes/test_function.py
+++ b/tests/nodes/test_function.py
@@ -2,7 +2,18 @@ from types import FunctionType
 
 import pytest
 
-from nodes import Binary, BinaryOp, Function, Parameter, Var, Let, Int, Print, Call
+from nodes import (
+    Binary,
+    BinaryOp,
+    Function,
+    Parameter,
+    Var,
+    Let,
+    Int,
+    Print,
+    Call,
+    HashableDict,
+)
 
 
 class TestFunction:
@@ -19,7 +30,7 @@ class TestFunction:
             ),
         ).execute()
 
-        assert isinstance(result, FunctionType)
+        assert isinstance(result.__wrapped__, FunctionType)
 
     def test_should_return_a_function_that_executes_expected_term(self):
         result = Function(
@@ -66,7 +77,7 @@ class TestFunction:
             ),
         ).execute()
 
-        assert result(100, namespace={"bar": 200}) == 300
+        assert result(100, namespace=HashableDict({"bar": 200})) == 300
 
     def test_should_overwrite_variables_from_namespace(self):
         result = Function(
@@ -81,7 +92,7 @@ class TestFunction:
             ),
         ).execute()
 
-        assert result(100, 500, namespace={"bar": 200}) == 600
+        assert result(100, 500, namespace=HashableDict({"bar": 200})) == 600
 
     def test_should_allow_usage_of_variables_from_local_namespace(self):
         result = Let(

--- a/tests/nodes/test_if.py
+++ b/tests/nodes/test_if.py
@@ -1,4 +1,4 @@
-from nodes import Binary, BinaryOp, Bool, If, Int, Str, Var
+from nodes import Binary, BinaryOp, Bool, If, Int, Var, HashableDict
 
 
 class TestIf:
@@ -25,6 +25,6 @@ class TestIf:
             condition=Binary(Int(10), BinaryOp.Eq, Int(10)),
             then=Var("foo"),
             otherwise=Var("bar"),
-        ).execute(namespace={"foo": "foo value", "bar": "bar value"})
+        ).execute(namespace=HashableDict({"foo": "foo value", "bar": "bar value"}))
 
         assert result == "foo value"

--- a/tests/nodes/test_let.py
+++ b/tests/nodes/test_let.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from nodes import Let, Parameter, Print, Str, Var
+from nodes import Let, Parameter, Print, Str, Var, HashableDict
 
 
 class TestLet:
@@ -18,7 +18,7 @@ class TestLet:
             name=Parameter("value"),
             value=Str("foo"),
             next=Print(Var("bar")),
-        ).execute(namespace={"bar": "global value"})
+        ).execute(namespace=HashableDict({"bar": "global value"}))
 
         mock_print.assert_called_with("global value")
 
@@ -28,6 +28,6 @@ class TestLet:
             name=Parameter("value"),
             value=Str("local value"),
             next=Print(Var("value")),
-        ).execute(namespace={"value": "global value"})
+        ).execute(namespace=HashableDict({"value": "global value"}))
 
         mock_print.assert_called_with("local value")

--- a/tests/nodes/test_print.py
+++ b/tests/nodes/test_print.py
@@ -17,6 +17,7 @@ from nodes import (
     Str,
     Tuple,
     Var,
+    HashableDict,
 )
 
 
@@ -35,7 +36,7 @@ class TestPrint:
         ],
     )
     def test_should_print_sent_value(self, mock_print, value, expected_message):
-        Print(value).execute(namespace={"foo": "foo value"})
+        Print(value).execute(namespace=HashableDict({"foo": "foo value"}))
 
         mock_print.assert_called_with(expected_message)
 
@@ -98,7 +99,7 @@ class TestPrint:
         ],
     )
     def test_should_return_value(self, mock_print, value, expected_value):
-        result = Print(value).execute(namespace={"foo": "foo value"})
+        result = Print(value).execute(namespace=HashableDict({"foo": "foo value"}))
 
         assert result == expected_value
 
@@ -107,4 +108,4 @@ class TestPrint:
         function = Function(parameters=[], value=Int(10))
         result = Print(function).execute()
 
-        assert isinstance(result, FunctionType)
+        assert isinstance(result.__wrapped__, FunctionType)

--- a/tests/nodes/test_second.py
+++ b/tests/nodes/test_second.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nodes import Int, Second, Tuple, Var
+from nodes import Int, Second, Tuple, Var, HashableDict
 
 
 class TestSecond:
@@ -24,6 +24,6 @@ class TestSecond:
                 Var("foo"),
                 Var("bar"),
             )
-        ).execute(namespace={"foo": "foo value", "bar": "bar value"})
+        ).execute(namespace=HashableDict({"foo": "foo value", "bar": "bar value"}))
 
         assert result == "bar value"

--- a/tests/nodes/test_tuple.py
+++ b/tests/nodes/test_tuple.py
@@ -1,4 +1,4 @@
-from nodes import Str, Tuple, Var
+from nodes import Str, Tuple, Var, HashableDict
 
 
 class TestTuple:
@@ -14,6 +14,6 @@ class TestTuple:
         result = Tuple(
             first=Var("foo"),
             second=Var("bar"),
-        ).execute(namespace={"foo": "Hello", "bar": "World"})
+        ).execute(namespace=HashableDict({"foo": "Hello", "bar": "World"}))
 
         assert result == ("Hello", "World")

--- a/tests/nodes/test_var.py
+++ b/tests/nodes/test_var.py
@@ -1,14 +1,14 @@
-from nodes import Var
+from nodes import Var, HashableDict
 
 
 class TestVar:
     def test_should_return_value_from_namespace(self):
-        result = Var("foo").execute(namespace={"foo": "bar"})
+        result = Var("foo").execute(namespace=HashableDict({"foo": "bar"}))
 
         assert result == "bar"
 
     def test_should_return_nothing_when_variable_doesnt_exist(self):
-        result = Var("foo").execute(namespace={})
+        result = Var("foo").execute(namespace=HashableDict({}))
 
         assert result is None
 


### PR DESCRIPTION
Moving namespace to a `HashableDict` by default reduced recursion depth. Also, because this code isn't optimized to handle insane recursion depth I simple increased python's recursion limit with the drawback of receiving an `SEGV` if its upper than max depth allowed by the os.