### PR TITLE
fix: nested calls for first and second functions

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -222,10 +222,12 @@ class First:
         self.value = value
 
     def execute(self, **kwargs):
-        if not isinstance(self.value, Tuple):
-            raise RuntimeError(f"Expected a tuple, given {type(self.value)}")
+        result = self.value.execute(**kwargs)
 
-        first, _ = self.value.execute(**kwargs)
+        if not isinstance(result, tuple):
+            raise RuntimeError(f"Expected a tuple, given {type(result)}")
+
+        first, _ = result
 
         return first
 
@@ -239,10 +241,12 @@ class Second:
         self.value = value
 
     def execute(self, **kwargs):
-        if not isinstance(self.value, Tuple):
-            raise RuntimeError(f"Expected a tuple, given {type(self.value)}")
+        result = self.value.execute(**kwargs)
 
-        _, second = self.value.execute(**kwargs)
+        if not isinstance(result, tuple):
+            raise RuntimeError(f"Expected a tuple, given {type(result)}")
+
+        _, second = result
 
         return second
 

--- a/tests/nodes/test_first.py
+++ b/tests/nodes/test_first.py
@@ -27,3 +27,18 @@ class TestFirst:
         ).execute(namespace=HashableDict({"foo": "foo value", "bar": "bar value"}))
 
         assert result == "foo value"
+
+    def test_should_allow_nested_calls(self):
+        result = First(
+            First(
+                Tuple(
+                    Tuple(
+                        Int(10),
+                        Int(20),
+                    ),
+                    Int(30),
+                )
+            ),
+        ).execute()
+
+        assert result == 10

--- a/tests/nodes/test_second.py
+++ b/tests/nodes/test_second.py
@@ -27,3 +27,18 @@ class TestSecond:
         ).execute(namespace=HashableDict({"foo": "foo value", "bar": "bar value"}))
 
         assert result == "bar value"
+
+    def test_should_allow_nested_calls(self):
+        result = Second(
+            Second(
+                Tuple(
+                    Int(10),
+                    Tuple(
+                        Int(20),
+                        Int(30),
+                    ),
+                )
+            ),
+        ).execute()
+
+        assert result == 30


### PR DESCRIPTION
Should pass the following example:

```
let f1 = fn (c) => {
  let e = fn () => "e";
  let f2 = ("a", "b");

  fn (d) => {
    (f2, (c, (d, e() + "fg")))
  }
};
let f3 = f1("c");
print(first(first(f3("d"))))
```